### PR TITLE
test: Fedora 36 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
-# Cisco Packet Tracer latest version on Fedora 35
+# Cisco Packet Tracer latest version on Fedora
 
-Easily install Cisco Packet Tracer latest version on Fedora 35. This installation script automatically detects a Cisco Packet Tracer `.deb` in any directory on `/home`.
+Easily install Cisco Packet Tracer latest version on Fedora. This installation script automatically detects a Cisco Packet Tracer `.deb` in any directory on `/home`.
+
+## Supported Fedora versions
+
+- 34
+- 35
+- 36
 
 ## Install
 


### PR DESCRIPTION
I did a test on Fedora 36 Beta and Cisco Packet Tracer works like a charm!
Cisco Packet Tracer version: 8.1.1