### PR TITLE
Update install file to match with previous, latest, and future versions

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -2,8 +2,9 @@
 
 # Find Cisco Packet Tracer installer
 installer_name_1=CiscoPacketTracer*Ubuntu_64bit.deb
-installer_name_2=Cisco*.deb
-path_to_pt=$(find /home -name $installer_name_1 -o -name $installer_name_2)
+installer_name_2=Cisco_Packet_Tracer_*_Ubuntu_64bit_*.deb
+installer_name_3=Cisco*.deb
+path_to_pt=$(find /home -name $installer_name_1 -o -name $installer_name_2 -o -name $installer_name_3)
 
 if [[ -z "$path_to_pt" ]]; then
     echo "Packet Tracer installer not found in /home. It must be named like this: $installer_name."

--- a/install.sh
+++ b/install.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 
 # Find Cisco Packet Tracer installer
-installer_name=CiscoPacketTracer*Ubuntu_64bit.deb
-path_to_pt=$(find /home -name $installer_name)
+installer_name_1=CiscoPacketTracer*Ubuntu_64bit.deb
+installer_name_2=Cisco*.deb
+path_to_pt=$(find /home -name $installer_name_1 -o -name $installer_name_2)
 
 if [[ -z "$path_to_pt" ]]; then
     echo "Packet Tracer installer not found in /home. It must be named like this: $installer_name."


### PR DESCRIPTION
Hi! 
In the latest version of Cisco packet tracer they changed the filename pattern from `CiscoPacketTracer*Ubuntu_64bit.deb` to `Cisco_Packet_Tracer_*_Ubuntu_64bit_*.deb`.
So I updated the installation file to match and work with the previous, latest, and any future patterns.
