### PR TITLE
install.sh: add --no-sandbox args via regex

### DIFF
--- a/cisco-pt.desktop
+++ b/cisco-pt.desktop
@@ -1,8 +1,0 @@
-[Desktop Entry]
-Type=Application
-Exec=/opt/pt/packettracer --no-sandbox args
-Name=Packet Tracer 8.1
-Icon=/opt/pt/art/app.png
-Terminal=false
-StartupNotify=true
-MimeType=application/x-pkt;application/x-pka;application/x-pkz;application/x-pks;application/x-pksz;

--- a/install.sh
+++ b/install.sh
@@ -35,7 +35,7 @@ tar -xvf packettracer/data.tar.xz --directory=packettracer
 
 sudo cp -r packettracer/usr /
 sudo cp -r packettracer/opt /
-sudo cp --force cisco-pt.desktop /usr/share/applications/cisco-pt.desktop
+sudo sed -i 's/packettracer/packettracer --no-sandbox args/' /usr/share/applications/cisco-pt.desktop
 sudo ./packettracer/postinst
 
 echo "Installing dependencies"


### PR DESCRIPTION
Now the script will apply a regex that add '`--no-sandbox args`' to
the `cisco-pt.desktop` file instead copy the file from the repo to the
application directory in `/usr/share/applications/`.